### PR TITLE
Added a note for CPU-only users to the README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ R-FCN: Object Detection via Region-based Fully Convolutional Networks
 
 **It is highly recommended to use the [MXNet version of R-FCN/Deformable R-FCN](https://github.com/msracver/Deformable-ConvNets), which supports multi-GPU train/test.**
 
+**WARNING: This code does not support CPU-only mode.** (See https://github.com/Orpine/py-R-FCN/issues/28).
 
 ### Disclaimer
 


### PR DESCRIPTION
People spend their time (e.g. compiling caffe) to make this code work in CPU-only mode. However, they get a "Segmentation fault (core dumped)" error  without any further explanation. Due to an issue (https://github.com/Orpine/py-R-FCN/issues/28), CPU-only mode is currently not available.