### PR TITLE
demo,demo_rfcn use cpu version of nms when in cpu_mode

### DIFF
--- a/tools/demo.py
+++ b/tools/demo.py
@@ -128,6 +128,7 @@ if __name__ == '__main__':
 
     if args.cpu_mode:
         caffe.set_mode_cpu()
+        cfg.USE_GPU_NMS = False
     else:
         caffe.set_mode_gpu()
         caffe.set_device(args.gpu_id)

--- a/tools/demo_rfcn.py
+++ b/tools/demo_rfcn.py
@@ -127,6 +127,7 @@ if __name__ == '__main__':
 
     if args.cpu_mode:
         caffe.set_mode_cpu()
+        cfg.USE_GPU_NMS = False
     else:
         caffe.set_mode_gpu()
         caffe.set_device(args.gpu_id)


### PR DESCRIPTION
nms_wrapper.py uses CPU mode when cfg.USE_GPU_NMS isn't set or it's passed force_cpu as True.

When --cpu was provided, demo.py and demo_rfcn.py did not set cfg.USE_GPU_NMS, which defaulted to True. So, NMS always operated in GPU mode. This caused sometimes the console to spew 'unknown error', and the bounding boxes on each object to not be combined; in other setups the program did not run at all.