### PR TITLE
docs: fix simple typo, offcial -> official

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ R-FCN: Object Detection via Region-based Fully Convolutional Networks
 
 The official R-FCN code (written in MATLAB) is available [here](https://github.com/daijifeng001/R-FCN).
 
-py-R-FCN is modified from [the offcial R-FCN implementation](https://github.com/daijifeng001/R-FCN) and  [py-faster-rcnn code](https://github.com/rbgirshick/py-faster-rcnn ), and the usage is quite similar to [py-faster-rcnn](https://github.com/rbgirshick/py-faster-rcnn ).
+py-R-FCN is modified from [the official R-FCN implementation](https://github.com/daijifeng001/R-FCN) and  [py-faster-rcnn code](https://github.com/rbgirshick/py-faster-rcnn ), and the usage is quite similar to [py-faster-rcnn](https://github.com/rbgirshick/py-faster-rcnn ).
 
 There are slight differences between py-R-FCN and the official R-FCN implementation.
  - py-R-FCN is ~10% slower at test-time, because some operations execute on the CPU in Python layers (e.g., 90ms / image vs. 99ms / image for ResNet-50)


### PR DESCRIPTION
There is a small typo in README.md.

Should read `official` rather than `offcial`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md